### PR TITLE
Remove Node deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ It contains the following differences:
   - Serverless Components support have been removed: these are old and unmaintained projects, it's very unlikely you are using them. That improves the boot time of the CLI.
   - Removed unused dependencies. 
   - Auto-updating has been removed (because it's not working anymore).
+- Fixed a node warning ("The `punycode` module is deprecated").
 
 ## Get Started
 

--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
     "sinon-chai": "^3.7.0",
     "standard-version": "^9.5.0"
   },
+  "overrides": {
+    "node-fetch": {
+      "whatwg-url": "^12.0.0"
+    }
+  },
   "eslintConfig": {
     "extends": "@serverless/eslint-config/node/12",
     "root": true,


### PR DESCRIPTION
```
(node:70686) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```

Caused by `whatwg-url` required by `node-fetch`. Tracked in https://github.com/node-fetch/node-fetch/issues/1797

Not resolved in node-fetch v2, impossible to upgrade to v3 because it is ESM now.

Inspired from https://github.com/mattermost/mattermost/pull/27463